### PR TITLE
3: add license slides

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -2,6 +2,26 @@
 title: "Good Software Engineering Practice for R Packages"
 ---
 
+<!--
+Creators (initial authors): 
+- Daniel Sabanes Bove, https://github.com/danielinteractive/ and www.linkedin.com/in/danielsabanesbove/
+- Friedrich Pahlke, https://github.com/fpahlke/ and www.linkedin.com/in/pahlke/
+- Kevin Kunzmann, https://github.com/kkmann/ and https://www.linkedin.com/in/kevin-kunzmann-6486a11bb/
+- Liming Li, https://github.com/clarkliming
+- Joe Zhu, https://github.com/shajoezhu and http://www.linkedin.com/in/joe-zhu-464b5818
+- Shuang Li, https://github.com/shuangli22
+In the current version, changes were done by (later authors):
+- Ya Wang, https://www.linkedin.com/in/ya-wang-98531524/ and https://github.com/ywang-gilead
+- Matt Secrest, https://www.linkedin.com/in/matthewsecrest/ and https://github.com/mattsecrest
+- Laura Pascasio Harris, https://www.linkedin.com/in/laura-h-33a96635/ and https://github.com/laurapharris
+- Daniel Sjoberg, https://www.linkedin.com/in/ddsjoberg/ and https://github.com/ddsjoberg
+License: This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License.
+To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/4.0/.
+The source files are hosted at https://github.com/openpharma/workshop-r-swe-sf, which is forked from
+the original version at https://github.com/openpharma/workshop-r-swe.
+Important: To use this work you must provide the name of the creators (initial authors), a link to the material, a link to the license, and indicate if changes were made.
+--> 
+
 Welcome to the homepage of the workshop *"Good Software Engineering Practice for R Packages"*. In this course participants will learn hands-on skills and tools to engineer reliable R packages used in biostatistics. The day will be a mix of presentations and exercises. Participants need to be comfortable with writing functions in R and use their own laptops.
 
 ## Next Event

--- a/slides/01_intro.qmd
+++ b/slides/01_intro.qmd
@@ -229,3 +229,22 @@ knitr::include_graphics("resources/pkg_graph.png")
     -   easier to document
 
 # Question, Comments?
+
+# License information
+
+- Creators (initial authors): 
+  Daniel Sabanes Bove [`r fontawesome::fa("github")`](https://github.com/danielinteractive/) [`r fontawesome::fa("linkedin")`](https://www.linkedin.com/in/danielsabanesbove/),
+  Friedrich Pahlke [`r fontawesome::fa("github")`](https://github.com/fpahlke/) [`r fontawesome::fa("linkedin")`](https://www.linkedin.com/in/pahlke/),
+  Kevin Kunzmann [`r fontawesome::fa("github")`](https://github.com/kkmann/) [`r fontawesome::fa("linkedin")`](https://www.linkedin.com/in/kevin-kunzmann-6486a11bb/)
+- In the current version, changes were done by (later authors):
+  Ya Wang [`r fontawesome::fa("github")`](https://github.com/ywang-gilead)
+  [`r fontawesome::fa("linkedin")`](https://www.linkedin.com/in/ya-wang-98531524/), 
+  Matt Secrest [`r fontawesome::fa("github")`](https://github.com/mattsecrest)
+  [`r fontawesome::fa("linkedin")`](https://www.linkedin.com/in/matthewsecrest/), 
+  Laura Pascasio Harris [`r fontawesome::fa("github")`](https://github.com/laurapharris)
+  [`r fontawesome::fa("linkedin")`](https://www.linkedin.com/in/laura-h-33a96635/), 
+  Daniel Sjoberg [`r fontawesome::fa("github")`](https://www.linkedin.com/in/ddsjoberg/)
+  [`r fontawesome::fa("linkedin")`](https://github.com/ddsjoberg)
+- This work is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
+- The source files are hosted at [github.com/openpharma/workshop-r-swe-sf](https://github.com/openpharma/workshop-r-swe-sf), which is forked from the original version at [github.com/openpharma/workshop-r-swe](https://github.com/openpharma/workshop-r-swe/).
+- Important: To use this work you must provide the name of the creators (initial authors), a link to the material, a link to the license, and indicate if changes were made

--- a/slides/02_r_packages.qmd
+++ b/slides/02_r_packages.qmd
@@ -316,3 +316,14 @@ export(my_sum)
 - [Writing R Extensions](https://cran.r-project.org/doc/manuals/R-exts.html)
 - [Rewriting R code in C++](https://adv-r.hadley.nz/rcpp.html)
 - [Super technical details about R Markdown](https://www.youtube.com/watch?v=fiy32LjgGUE)
+
+# License information
+
+- Creators (initial authors): 
+  Daniel Sabanes Bove [`r fontawesome::fa("github")`](https://github.com/danielinteractive/) [`r fontawesome::fa("linkedin")`](https://www.linkedin.com/in/danielsabanesbove/),
+  Liming Li [`r fontawesome::fa("github")`](https://github.com/clarkliming)
+- In the current version, changes were done by (later authors): 
+  TODO: FILL IN, OR IF NOT APPLICABLE DELETE THIS BULLET
+- This work is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
+- The source files are hosted at [github.com/openpharma/workshop-r-swe-sf](https://github.com/openpharma/workshop-r-swe-sf), which is forked from the original version at [github.com/openpharma/workshop-r-swe](https://github.com/openpharma/workshop-r-swe/).
+- Important: To use this work you must provide the name of the creators (initial authors), a link to the material, a link to the license, and indicate if changes were made

--- a/slides/03_workflow.qmd
+++ b/slides/03_workflow.qmd
@@ -578,3 +578,13 @@ Document your functions with
 -   Wickham, H. (2019). Advanced R, Second Edition.\
     Taylor & Francis Ltd. \[[Book](https://amzn.to/3uLnxLd) \|
     [Online](https://adv-r.hadley.nz/)\]
+    
+# License information
+
+- Creators (initial authors): 
+  Friedrich Pahlke [`r fontawesome::fa("github")`](https://github.com/fpahlke/) [`r fontawesome::fa("linkedin")`](https://www.linkedin.com/in/pahlke/)
+- In the current version, changes were done by (later authors): 
+  TODO: FILL IN, OR IF NOT APPLICABLE DELETE THIS BULLET
+- This work is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
+- The source files are hosted at [github.com/openpharma/workshop-r-swe-sf](https://github.com/openpharma/workshop-r-swe-sf), which is forked from the original version at [github.com/openpharma/workshop-r-swe](https://github.com/openpharma/workshop-r-swe/).
+- Important: To use this work you must provide the name of the creators (initial authors), a link to the material, a link to the license, and indicate if changes were made

--- a/slides/04_quality.qmd
+++ b/slides/04_quality.qmd
@@ -706,3 +706,14 @@ Check if your package is ready for use in production with the
     Taylor & Francis Inc. \[[Book](https://amzn.to/3Bk6elt)\]
 -   Martin, R. (2008). Clean Code: A Handbook of Agile Software Craftsmanship
     (1st Edition). Prentice Hall. \[[Book](https://amzn.to/3IKuSS4)\]
+
+# License information
+
+- Creators (initial authors): 
+  Friedrich Pahlke [`r fontawesome::fa("github")`](https://github.com/fpahlke/) [`r fontawesome::fa("linkedin")`](https://www.linkedin.com/in/pahlke/), 
+  Joe Zhu [`r fontawesome::fa("github")`](https://github.com/shajoezhu) [`r fontawesome::fa("linkedin")`](http://www.linkedin.com/in/joe-zhu-464b5818)
+- In the current version, changes were done by (later authors): 
+  TODO: FILL IN, OR IF NOT APPLICABLE DELETE THIS BULLET
+- This work is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
+- The source files are hosted at [github.com/openpharma/workshop-r-swe-sf](https://github.com/openpharma/workshop-r-swe-sf), which is forked from the original version at [github.com/openpharma/workshop-r-swe](https://github.com/openpharma/workshop-r-swe/).
+- Important: To use this work you must provide the name of the creators (initial authors), a link to the material, a link to the license, and indicate if changes were made

--- a/slides/05_collaboration.qmd
+++ b/slides/05_collaboration.qmd
@@ -360,3 +360,14 @@ sequenceDiagram
 -   **Can you fix the errors with some pull requests?**
 -   The purpose of this exercise is to explore the collaboration
     functionality of GitHub - not to produce a perfect package ;)
+
+# License information
+
+- Creators (initial authors): 
+  Kevin Kunzmann [`r fontawesome::fa("github")`](https://github.com/kkmann/) [`r fontawesome::fa("linkedin")`](https://www.linkedin.com/in/kevin-kunzmann-6486a11bb/),
+  Shuang Li [`r fontawesome::fa("github")`](https://github.com/shuangli22)
+- In the current version, changes were done by (later authors): 
+  TODO: FILL IN, OR IF NOT APPLICABLE DELETE THIS BULLET
+- This work is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
+- The source files are hosted at [github.com/openpharma/workshop-r-swe-sf](https://github.com/openpharma/workshop-r-swe-sf), which is forked from the original version at [github.com/openpharma/workshop-r-swe](https://github.com/openpharma/workshop-r-swe/).
+- Important: To use this work you must provide the name of the creators (initial authors), a link to the material, a link to the license, and indicate if changes were made

--- a/slides/06_publication.qmd
+++ b/slides/06_publication.qmd
@@ -233,3 +233,15 @@ Use the same repository created from template [https://github.com/kkmann/simulat
   - Need to change remote to `git`
 - Deploy the website through `use_github_action("pkgdown")`
   - (Optional) Check the automatic github page deploy action
+
+# License information
+
+- Creators (initial authors): 
+  Daniel Sabanes Bove [`r fontawesome::fa("github")`](https://github.com/danielinteractive/) [`r fontawesome::fa("linkedin")`](https://www.linkedin.com/in/danielsabanesbove/),
+  Friedrich Pahlke [`r fontawesome::fa("github")`](https://github.com/fpahlke/) [`r fontawesome::fa("linkedin")`](https://www.linkedin.com/in/pahlke/),
+  Liming Li [`r fontawesome::fa("github")`](https://github.com/clarkliming)
+- In the current version, changes were done by (later authors): 
+  TODO: FILL IN, OR IF NOT APPLICABLE DELETE THIS BULLET
+- This work is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
+- The source files are hosted at [github.com/openpharma/workshop-r-swe-sf](https://github.com/openpharma/workshop-r-swe-sf), which is forked from the original version at [github.com/openpharma/workshop-r-swe](https://github.com/openpharma/workshop-r-swe/).
+- Important: To use this work you must provide the name of the creators (initial authors), a link to the material, a link to the license, and indicate if changes were made

--- a/slides/07_shiny.qmd
+++ b/slides/07_shiny.qmd
@@ -444,3 +444,14 @@ You'll need few extra steps:
   Engineering Production-Grade Shiny Apps. [https://engineering-shiny.org/](https://engineering-shiny.org/)
 - Colin Gillespie (2019). R and Security Talk at useR 2019.
   \[[Youtube recording](https://www.youtube.com/watch?v=5odJxZj9LE4)\]
+
+# License information
+
+- Creators (initial authors): 
+  Daniel Sabanes Bove [`r fontawesome::fa("github")`](https://github.com/danielinteractive/) [`r fontawesome::fa("linkedin")`](https://www.linkedin.com/in/danielsabanesbove/),
+  Joe Zhu [`r fontawesome::fa("github")`](https://github.com/shajoezhu) [`r fontawesome::fa("linkedin")`](http://www.linkedin.com/in/joe-zhu-464b5818)
+- In the current version, changes were done by (later authors): 
+  TODO: FILL IN, OR IF NOT APPLICABLE DELETE THIS BULLET
+- This work is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
+- The source files are hosted at [github.com/openpharma/workshop-r-swe-sf](https://github.com/openpharma/workshop-r-swe-sf), which is forked from the original version at [github.com/openpharma/workshop-r-swe](https://github.com/openpharma/workshop-r-swe/).
+- Important: To use this work you must provide the name of the creators (initial authors), a link to the material, a link to the license, and indicate if changes were made

--- a/slides/08_conclusion.qmd
+++ b/slides/08_conclusion.qmd
@@ -86,3 +86,13 @@ image: thumbnails/conclusion.jpg
 -   Start building your first own package and share internally first
 -   Later publish it open source on GitHub and submit it to CRAN
 -   Learn about more tips and tricks how to extend R
+
+# License information
+
+- Creators (initial authors): 
+  Daniel Sabanes Bove [`r fontawesome::fa("github")`](https://github.com/danielinteractive/) [`r fontawesome::fa("linkedin")`](https://www.linkedin.com/in/danielsabanesbove/)
+- In the current version, changes were done by (later authors): 
+  TODO: FILL IN, OR IF NOT APPLICABLE DELETE THIS BULLET
+- This work is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
+- The source files are hosted at [github.com/openpharma/workshop-r-swe-sf](https://github.com/openpharma/workshop-r-swe-sf), which is forked from the original version at [github.com/openpharma/workshop-r-swe](https://github.com/openpharma/workshop-r-swe/).
+- Important: To use this work you must provide the name of the creators (initial authors), a link to the material, a link to the license, and indicate if changes were made


### PR DESCRIPTION
closes #3

Hi @ywang-gilead , this is so that we are complicant with the CC-BY license - the only thing left to do would be to see which of the current authors edited any of the slide files potentially (e.g. adding content etc.) and then adding those names with icons (see the intro file for copy/pasting) or just removing the line where it says changes have been made if no changes were made.